### PR TITLE
refactor(common): 공용 클래스 common 패키지로 이동

### DIFF
--- a/src/main/java/com/example/simplesns/common/config/PasswordEncoder.java
+++ b/src/main/java/com/example/simplesns/common/config/PasswordEncoder.java
@@ -1,4 +1,4 @@
-package com.example.simplesns.config;
+package com.example.simplesns.common.config;
 
 import at.favre.lib.crypto.bcrypt.BCrypt;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/example/simplesns/common/config/WebConfig.java
+++ b/src/main/java/com/example/simplesns/common/config/WebConfig.java
@@ -1,6 +1,6 @@
-package com.example.simplesns.config;
+package com.example.simplesns.common.config;
 
-import com.example.simplesns.filter.LoginFilter;
+import com.example.simplesns.common.filter.LoginFilter;
 import jakarta.servlet.Filter;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/com/example/simplesns/common/consts/Const.java
+++ b/src/main/java/com/example/simplesns/common/consts/Const.java
@@ -1,4 +1,4 @@
-package com.example.simplesns.common;
+package com.example.simplesns.common.consts;
 
 public class Const {
     public static final String LOGIN_USER = "loginUser";

--- a/src/main/java/com/example/simplesns/common/entity/BaseEntity.java
+++ b/src/main/java/com/example/simplesns/common/entity/BaseEntity.java
@@ -1,4 +1,4 @@
-package com.example.simplesns.common;
+package com.example.simplesns.common.entity;
 
 import jakarta.persistence.*;
 import lombok.Getter;

--- a/src/main/java/com/example/simplesns/common/filter/LoginFilter.java
+++ b/src/main/java/com/example/simplesns/common/filter/LoginFilter.java
@@ -1,6 +1,6 @@
-package com.example.simplesns.filter;
+package com.example.simplesns.common.filter;
 
-import com.example.simplesns.common.Const;
+import com.example.simplesns.common.consts.Const;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.*;
 import jakarta.servlet.http.HttpServletRequest;
@@ -8,7 +8,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.util.PatternMatchUtils;
 
 import java.io.IOException;
 import java.time.LocalDateTime;

--- a/src/main/java/com/example/simplesns/domain/user/entity/User.java
+++ b/src/main/java/com/example/simplesns/domain/user/entity/User.java
@@ -1,6 +1,6 @@
 package com.example.simplesns.domain.user.entity;
 
-import com.example.simplesns.common.BaseEntity;
+import com.example.simplesns.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;


### PR DESCRIPTION
공용으로 사용하는 클래스들을 common 패키지로 이동시켰습니다.

entity 생성하실 때 상속받아야하는 BaseEntity도 com.example.simplesns.common.entity로 위치가 변경됐으니 참고해주세요!